### PR TITLE
milli prefix is for 1,000 (a thousand) not for 10,000 (ten thousand)

### DIFF
--- a/src/utils/near.ts
+++ b/src/utils/near.ts
@@ -13,14 +13,14 @@ export const units = [
 // eslint-disable-next-line no-unused-vars
 const toNearFromX: {[key: string]: (_: number) => number} = {
     'NEAR': (f: number) => f, // no-op
-    'milliNEAR': (f: number) => f * 0.0001,
+    'milliNEAR': (f: number) => f * 0.001,
     'yoctoNEAR': (f: number) => f * Math.pow(10, -24),
     'TGas': (f: number) => f * Math.pow(10, -5)
 };
 
 const precisionTable: {[key: string]: number} = {
     'NEAR': 0,
-    'milliNEAR': 4,
+    'milliNEAR': 3,
     'yoctoNEAR': 24,
     'TGas': 0
 };
@@ -30,7 +30,7 @@ const precisionTable: {[key: string]: number} = {
 const toXFromNear: {[key: string]: (_: number) => number} = {
     /* Y: X */
     'NEAR': (f: number) => f,
-    'milliNEAR': (f: number) => f * 10000,
+    'milliNEAR': (f: number) => f * 1000,
     'yoctoNEAR': (f: number) => f * Math.pow(10, 24),
     'TGas': (f: number) => f * Math.pow(10, 5)
 };


### PR DESCRIPTION
From wikipedia 👇

**Milli** (symbol m) is a [unit prefix](https://en.wikipedia.org/wiki/Metric_prefix) in the [metric system](https://en.wikipedia.org/wiki/Metric_system) denoting a factor of one thousandth (10−3).[[1]](https://en.wikipedia.org/wiki/Milli-#cite_note-1) Proposed in 1793,[[2]](https://en.wikipedia.org/wiki/Milli-#cite_note-CTPM_1793-2) and adopted in 1795, the prefix comes from the [Latin](https://en.wikipedia.org/wiki/Latin) mille, meaning one thousand (the Latin plural is milia). Since 1960, the prefix is part of the [International System of Units](https://en.wikipedia.org/wiki/International_System_of_Units) (SI).
